### PR TITLE
Add the option to flash system, vendor and product images directly

### DIFF
--- a/recovery/root/system/etc/recovery.fstab
+++ b/recovery/root/system/etc/recovery.fstab
@@ -39,7 +39,9 @@ system                                                  /system                e
 #system_ext                                              /system_ext            ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 /dev/block/mapper/system                                /system_image          emmc    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 product                                                 /product               ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
+/dev/block/mapper/product                               /product_image         emmc    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 vendor                                                  /vendor                ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
+/dev/block/mapper/vendor                                /vendor_image          emmc    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 odm                                                     /odm                   ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 /dev/block/by-name/metadata                             /metadata              ext4    noatime,nosuid,nodev,discard                         wait,check,formattable,wrappedkey,first_stage_mount
 /dev/block/bootdevice/by-name/userdata                  /data                  f2fs    noatime,nosuid,nodev,nodiscard,reserve_root=32768,resgid=1065,fsync_mode=nobarrier,inlinecrypt    latemount,wait,check,formattable,fileencryption=ice,wrappedkey,keydirectory=/metadata/vold/metadata_encryption,quota,reservedsize=128M,sysfs_path=/sys/devices/platform/soc/1d84000.ufshc,checkpoint=fs

--- a/recovery/root/system/etc/recovery.fstab
+++ b/recovery/root/system/etc/recovery.fstab
@@ -36,7 +36,8 @@
 
 #<src>                                                 <mnt_point>            <type>  <mnt_flags and options>                            <fs_mgr_flags>
 system                                                  /system                ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
-system_ext                                              /system_ext            ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
+#system_ext                                              /system_ext            ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
+/dev/block/mapper/system                                /system_image          emmc    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 product                                                 /product               ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 vendor                                                  /vendor                ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount
 odm                                                     /odm                   ext4    ro,barrier=1,discard                                 wait,logical,first_stage_mount

--- a/recovery/root/system/etc/twrp.fstab
+++ b/recovery/root/system/etc/twrp.fstab
@@ -2,56 +2,58 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-# mount 		point  		fstype  	device                             device2                flags
+# mount		point		fstype		device                             device2                flags
 system		/system		ext4		logical
-system_ext	/system_ext	ext4		logical
+#system_ext	/system_ext	ext4		logical
 vendor		/vendor		ext4		display="Vendor";logical
-product		/product		ext4		display="Product";logical
-odm			/odm			ext4		display="Odm";logical
+product		/product	ext4		display="Product";logical
+odm		/odm		ext4		display="Odm";logical
 
-/cache				ext4		/dev/block/bootdevice/by-name/cache	
-/logfs            vfat     /dev/block/bootdevice/by-name/logfs        flags=display="logfs"
-/boot					emmc		/dev/block/bootdevice/by-name/boot
-/super				emmc     /dev/block/bootdevice/by-name/super		    flags=display="Super";backup=1;flashimg=1
-/metadata			ext4		/dev/block/by-name/metadata     flags=display="Metadata";backup=1
-/metadata_image   emmc     /dev/block/by-name/metadata     flags=display="metadata";flashimg=1
-/data   				f2fs     /dev/block/bootdevice/by-name/userdata 	 flags=fileencryption=ice;wrappedkey;keydirectory=/metadata/vold/metadata_encryption
-/recovery			emmc     /dev/block/bootdevice/by-name/recovery     flags=display="Recovery";backup=1;flashimg=1
-/firmware			vfat		/dev/block/bootdevice/by-name/modem			 flags=display="Firmware";mounttodecrypt;fsflags=ro
-/firmware_image   emmc     /dev/block/bootdevice/by-name/modem        flags=display="Firmware";flashimg=1;backup=1
-/misc					emmc		/dev/block/bootdevice/by-name/misc
-/modem				emmc		/dev/block/bootdevice/by-name/modem			 flags=backup=1;display="Modem"
-/bluetooth			emmc		/dev/block/bootdevice/by-name/bluetooth	 flags=backup=1;subpartitionof=/modem
-/dsp					emmc		/dev/block/bootdevice/by-name/dsp			 flags=backup=1;subpartitionof=/modem
-/dsp_image        emmc     /dev/block/bootdevice/by-name/dsp          flags=display="dsp";flashimg=1
-/efs1					emmc		/dev/block/bootdevice/by-name/modemst1	 	 flags=backup=1;display="EFS"
-/efs2					emmc		/dev/block/bootdevice/by-name/modemst2		 flags=backup=1;subpartitionof=/efs1
-/efsc					emmc		/dev/block/bootdevice/by-name/fsc			 flags=backup=1;subpartitionof=/efs1
-/efsg					emmc		/dev/block/bootdevice/by-name/fsg			 flags=backup=1;subpartitionof=/efs1
-/vbmeta				emmc		/dev/block/bootdevice/by-name/vbmeta		 flags=display="Vbmeta";backup=1;flashimg=1
-/vbmeta_system		emmc		/dev/block/bootdevice/by-name/vbmeta_system flags=display="Vbmeta system";backup=1;flashimg=1
-/exaid				emmc		/dev/block/bootdevice/by-name/exaid			 flags=display="Exaid";backup=1;flashimg=1
-/cust             ext4     /dev/block/bootdevice/by-name/cust         flags=display="cust";backup=1
-/cust_image       emmc     /dev/block/bootdevice/by-name/cust         flags=display="cust";flashimg=1
-/logfs            vfat     /dev/block/bootdevice/by-name/logfs        flags=display="logfs";backup=1
-/spunvm           vfat     /dev/block/bootdevice/by-name/spunvm       flags=display="spunvm";backup=1
-/splash           emmc     /dev/block/bootdevice/by-name/splash       flags=display="splash";backup=1;flashimg=1
-/logo             emmc     /dev/block/bootdevice/by-name/logo         flags=display="logo";backup=1;flashimg=1
-/tz               emmc     /dev/block/bootdevice/by-name/tz           flags=display="tz";backup=1;flashimg=1
+# mount_point	 fstype			path					flags
+/system_image     emmc     /dev/block/mapper/system                         flags=display="System Image";backup=0;flashimg=1
+/cache		  ext4	   /dev/block/bootdevice/by-name/cache	
+/logfs            vfat     /dev/block/bootdevice/by-name/logfs              flags=display="logfs"
+/boot		  emmc	   /dev/block/bootdevice/by-name/boot
+/super		  emmc     /dev/block/bootdevice/by-name/super		    flags=display="Super";backup=1;flashimg=1
+/metadata	  ext4	   /dev/block/by-name/metadata                      flags=display="Metadata";backup=1
+/metadata_image   emmc     /dev/block/by-name/metadata                      flags=display="metadata";flashimg=1
+/data		  f2fs     /dev/block/bootdevice/by-name/userdata	    flags=fileencryption=ice;wrappedkey;keydirectory=/metadata/vold/metadata_encryption
+/recovery	  emmc     /dev/block/bootdevice/by-name/recovery           flags=display="Recovery";backup=1;flashimg=1
+/firmware	  vfat	   /dev/block/bootdevice/by-name/modem		    flags=display="Firmware";mounttodecrypt;fsflags=ro
+/firmware_image   emmc     /dev/block/bootdevice/by-name/modem              flags=display="Firmware";flashimg=1;backup=1
+/misc		  emmc	   /dev/block/bootdevice/by-name/misc
+/modem		  emmc	   /dev/block/bootdevice/by-name/modem		    flags=backup=1;display="Modem"
+/bluetooth	  emmc     /dev/block/bootdevice/by-name/bluetooth	    flags=backup=1;subpartitionof=/modem
+/dsp		  emmc	   /dev/block/bootdevice/by-name/dsp		    flags=backup=1;subpartitionof=/modem
+/dsp_image        emmc     /dev/block/bootdevice/by-name/dsp                flags=display="dsp";flashimg=1
+/efs1		  emmc	   /dev/block/bootdevice/by-name/modemst1	    flags=backup=1;display="EFS"
+/efs2		  emmc	   /dev/block/bootdevice/by-name/modemst2           flags=backup=1;subpartitionof=/efs1
+/efsc		  emmc	   /dev/block/bootdevice/by-name/fsc		    flags=backup=1;subpartitionof=/efs1
+/efsg		  emmc	   /dev/block/bootdevice/by-name/fsg		    flags=backup=1;subpartitionof=/efs1
+/vbmeta		  emmc	   /dev/block/bootdevice/by-name/vbmeta		    flags=display="Vbmeta";backup=1;flashimg=1
+/vbmeta_system	  emmc	   /dev/block/bootdevice/by-name/vbmeta_system      flags=display="Vbmeta system";backup=1;flashimg=1
+/exaid		  emmc	   /dev/block/bootdevice/by-name/exaid		    flags=display="Exaid";backup=1;flashimg=1
+/cust             ext4     /dev/block/bootdevice/by-name/cust               flags=display="cust";backup=1
+/cust_image       emmc     /dev/block/bootdevice/by-name/cust               flags=display="cust";flashimg=1
+/logfs            vfat     /dev/block/bootdevice/by-name/logfs              flags=display="logfs";backup=1
+/spunvm           vfat     /dev/block/bootdevice/by-name/spunvm             flags=display="spunvm";backup=1
+/splash           emmc     /dev/block/bootdevice/by-name/splash             flags=display="splash";backup=1;flashimg=1
+/logo             emmc     /dev/block/bootdevice/by-name/logo               flags=display="logo";backup=1;flashimg=1
+/tz               emmc     /dev/block/bootdevice/by-name/tz                 flags=display="tz";backup=1;flashimg=1
 /keystore         emmc     /dev/block/bootdevice/by-name/keystore
 /ssd              emmc     /dev/block/bootdevice/by-name/ssd
 /frp              emmc     /dev/block/bootdevice/by-name/frp
 /ddr              emmc     /dev/block/bootdevice/by-name/ddr
 /devinfo          emmc     /dev/block/bootdevice/by-name/devinfo
 /fsc              emmc     /dev/block/bootdevice/by-name/fsc
-/abl              emmc     /dev/block/bootdevice/by-name/abl          flags=display="abl";backup=1;flashimg=1
-#/msadp            emmc     /dev/block/bootdevice/by-name/msadp        flags=display="msadp";backup=1;flashimg=1
-#/apdp             emmc     /dev/block/bootdevice/by-name/apdp         flags=display="apdp";backup=1;flashimg=1
-/cmnlib64         emmc     /dev/block/bootdevice/by-name/cmnlib64     flags=display="cmnlib64";backup=1;flashimg=1
-/cmnlib           emmc     /dev/block/bootdevice/by-name/cmnlib       flags=display="cmnlib";backup=1;flashimg=1
-/keymaster        emmc     /dev/block/bootdevice/by-name/keymaster    flags=display="keymaster";backup=1;flashimg=1
-#/hyp              emmc     /dev/block/bootdevice/by-name/hyp          flags=display="hyp";backup=1;flashimg=1
-#/devcfg           emmc     /dev/block/bootdevice/by-name/devcfg       flags=display="devcfg";backup=1;flashimg=1
+/abl              emmc     /dev/block/bootdevice/by-name/abl                flags=display="abl";backup=1;flashimg=1
+#/msadp           emmc     /dev/block/bootdevice/by-name/msadp              flags=display="msadp";backup=1;flashimg=1
+#/apdp            emmc     /dev/block/bootdevice/by-name/apdp               flags=display="apdp";backup=1;flashimg=1
+/cmnlib64         emmc     /dev/block/bootdevice/by-name/cmnlib64           flags=display="cmnlib64";backup=1;flashimg=1
+/cmnlib           emmc     /dev/block/bootdevice/by-name/cmnlib             flags=display="cmnlib";backup=1;flashimg=1
+/keymaster        emmc     /dev/block/bootdevice/by-name/keymaster          flags=display="keymaster";backup=1;flashimg=1
+#/hyp             emmc     /dev/block/bootdevice/by-name/hyp                flags=display="hyp";backup=1;flashimg=1
+#/devcfg          emmc     /dev/block/bootdevice/by-name/devcfg             flags=display="devcfg";backup=1;flashimg=1
 # Removable storage
-/usb-otg				vfat     /dev/block/sdg1		/dev/block/sdg		  	 flags=fsflags=utf8;storage;wipeingui;removable
+/usb-otg	  vfat     /dev/block/sdg*				    flags=fsflags=utf8;storage;wipeingui;removable
 

--- a/recovery/root/system/etc/twrp.fstab
+++ b/recovery/root/system/etc/twrp.fstab
@@ -11,6 +11,8 @@ odm		/odm		ext4		display="Odm";logical
 
 # mount_point	 fstype			path					flags
 /system_image     emmc     /dev/block/mapper/system                         flags=display="System Image";backup=0;flashimg=1
+/vendor_image     emmc     /dev/block/mapper/vendor                         flags=display="Vendor Image";backup=0;flashimg=1
+/product_image    emmc     /dev/block/mapper/product                        flags=display="Product Image";backup=0;flashimg=1
 /cache		  ext4	   /dev/block/bootdevice/by-name/cache	
 /logfs            vfat     /dev/block/bootdevice/by-name/logfs              flags=display="logfs"
 /boot		  emmc	   /dev/block/bootdevice/by-name/boot


### PR DESCRIPTION
This will add the option to flash product image, vendor image and system image such as GSI directly without using fastbootd or special scripts.
Note :
This will add the warning :
Unable to update /system_image Logical partition
for system image and similar ones for the other 2 to the console.

It's totally upto you whether you want to add the option of flashing these images directly at the cost of a warning in the log or not.

If you want to add this and not get the warning , you'll need to apply patches to partitionmanager.cpp in bootable/recovery